### PR TITLE
v0.04

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Memoize-HashKey-Ignore
 
 {{$NEXT}}
+
+0.04      2018-06-04 09:37:35+08:00 Asia/Manila
         Fix typo in dist name (GH #7)
 
 0.03      2017-02-21 02:18:31+00:00 UTC

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,7 +31,7 @@ my %WriteMakefileArgs = (
     "Test::More" => "0.94",
     "Test::NoWarnings" => 0
   },
-  "VERSION" => "0.03",
+  "VERSION" => "0.04",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/lib/Memoize/HashKey/Ignore.pm
+++ b/lib/Memoize/HashKey/Ignore.pm
@@ -13,7 +13,7 @@ Memoize::HashKey::Ignore - allow certain keys not to be memoized.
 
 =cut
 
-our $VERSION = '0.03';
+our $VERSION = '0.04';
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Fix typo in dist name (GH #7)

Courtesy PR for fresh CPAN upload of [v0.04](https://metacpan.org/release/BINARY/Memoize-HashKey-Ignore-0.04)